### PR TITLE
refactor: Updated README, GH nightly build directory

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public/volumeviewer
+          publish_dir: ./public/vole-core
           tag_name: ${{ steps.prepare_tag.outputs.deploy_tag_name }}
           tag_message: "Deployment to gh-pages to test new viewer ${{ steps.prepare_tag.outputs.tag_name }}"

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ build
 demo
 public/dist
 public/demo
-public/volumeviewer
+public/vole-core
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are several ways to deliver volume data to the viewer:
 - Load raw TypedArrays of 3d volume data ( see `RawArrayLoader` and `Volume.setChannelDataFromVolume` ).
 - (legacy) Load texture atlases as .png files or Uint8Arrays containing volume slices tiled across a 2d image ( see `JsonImageInfoLoader` and `Volume.setChannelDataFromAtlas` ).
 
-# Example
+## Example
 
 See [`public/index.ts`](./public/index.ts) for a working example. (`npm install; npm run dev` will run that code)
 
@@ -59,19 +59,20 @@ view3D.addVolume(volume);
 loader.loadVolumeData(volume);
 ```
 
-# React example
+## React example
 
-See [vole-app](https://github.com/allen-cell-animated/website-3d-cell-viewer) for a complete application that wraps View3D in a React component.
+See [vole-app](https://github.com/allen-cell-animated/vole-app) for a complete application that wraps View3D in a React component.
 
-# Acknowledgements
+## Acknowledgements
 
 The ray marched volume shader is a heavily modified version of one that has its origins in [Bisque](http://bioimage.ucsb.edu/bisque).
 The core path tracing implementation was adapted from ExposureRender.
 
-## BisQue license
+### BisQue license
 
 Center for Bio-Image Informatics, University of California at Santa Barbara
 
+```text
 Copyright (c) 2007-2017 by the Regents of the University of California
 All rights reserved
 
@@ -106,14 +107,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The views and conclusions contained in the software and documentation
 are those of the authors and should not be interpreted as representing
 official policies, either expressed or implied, of the Regents of the University of California.
+```
 
 ## Exposure Render license
 
-    Copyright (c) 2011, T. Kroes <t.kroes@tudelft.nl>
-    All rights reserved.
-    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-    - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-    - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-    - Neither the name of the TU Delft nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+```text
+Copyright (c) 2011, T. Kroes <t.kroes@tudelft.nl>
+All rights reserved.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+- Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+- Neither the name of the TU Delft nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-demo": "vite build public/ --config vite.config.ts --outDir ./demo",
     "clean": "rimraf es/",
     "format": "prettier --write src/**/*.ts",
-    "gh-build": "vite build public/ --config vite.config.ts --outDir ./volumeviewer",
+    "gh-build": "vite build public/ --config vite.config.ts --outDir ./vole-core",
     "dev": "vite serve",
     "start": "vite serve",
     "lint": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore --ext .js --ext .ts ./src",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -13,7 +13,7 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 export default {
   entry: ["./public/index.ts"],
   output: {
-    path: path.resolve(__dirname, "volumeviewer"),
+    path: path.resolve(__dirname, "vole-core"),
     filename: "vol-e-ui.bundle.js",
   },
   devtool: "source-map",


### PR DESCRIPTION
# Problem

Handles a few remaining cleanup tasks now that the repository for this and `vole-app` have been renamed.

*Estimated review size: tiny, 5 minutes*

# Solution

- Updates links to the `vole-app` repo.
- Updates the default build folder for the GH nightly task.
- Formats the README license information.

