### PR TITLE
doc: Updated README text and added NPM links, removed outdated publishing steps

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -13,8 +13,9 @@
 
 - Requires that you are listed as a maintainer for this npm module
 
-* Commit and push changes
-* Login: `npm login`
 * Make sure you can run build successfully: `npm run build`
 * Update version: `npm version patch`
-* Publish: `npm publish`
+* Push to main: `git push origin main`
+* Push tags: `git push origin --tags vX.X.X`
+
+You do not need to run `npm publish` as the CI/CD pipeline will automatically publish the package to npm.

--- a/DEV.md
+++ b/DEV.md
@@ -11,11 +11,13 @@
 
 ## Publishing
 
-- Requires that you are listed as a maintainer for this npm module
+Requires that you have write access to `main` in this repository on GitHub. If
+you do not have write access, ask someone who does to publish a new version for
+you.
 
-* Make sure you can run build successfully: `npm run build`
-* Update version: `npm version patch`
-* Push to main: `git push origin main`
-* Push tags: `git push origin --tags vX.X.X`
+- Make sure you can run build successfully: `npm run build`
+- Update version: `npm version {major|minor|patch}`
+- Push to main: `git push origin main`
+- Push tags: `git push origin v{X.X.X}`
 
-You do not need to run `npm publish` as the CI/CD pipeline will automatically publish the package to npm.
+The CI/CD pipeline will automatically publish the package to npm.

--- a/DEV.md
+++ b/DEV.md
@@ -18,6 +18,6 @@ you.
 - Make sure you can run build successfully: `npm run build`
 - Update version: `npm version {major|minor|patch}`
 - Push to main: `git push origin main`
-- Push tags: `git push origin v{X.X.X}`
+- Push tags: `git push origin tag v{X.X.X}`
 
 The CI/CD pipeline will automatically publish the package to npm.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Vol-E core
 
-This is a WebGL canvas-based volume viewer. It can display multichannel volume data with high channel counts, and is optimized for OME-Zarr files. With OME-Zarr, the viewer can prefetch and cache Zarr chunks in browser memory for optimized performance.
+![NPM Version](https://img.shields.io/npm/v/%40aics%2Fvole-core)
+![NPM Last Update](https://img.shields.io/npm/last-update/%40aics%2Fvole-core)
+
+**Vol-E core** is a WebGL canvas-based volume viewer. It can display multichannel volume data with high channel counts. The viewer is optimized for OME-Zarr files, and can prefetch and cache Zarr chunks in browser memory for performance.
 
 The Vol-E core package exposes several key modules:
 
@@ -61,7 +64,7 @@ loader.loadVolumeData(volume);
 
 ## React example
 
-See [vole-app](https://github.com/allen-cell-animated/vole-app) for a complete application that wraps View3D in a React component.
+See [vole-app](https://github.com/allen-cell-animated/vole-app) for a complete application that wraps Vol-E core in a React component.
 
 ## Acknowledgements
 


### PR DESCRIPTION
Added a link to our NPM release and removed some outdated steps in the `DEV.md` documentation.

You can view the new README here: https://github.com/allen-cell-animated/vole-core/blob/7b3a6113bf4824846aef97a715ae1b4ac35fd400/README.md

*Estimated review size: tiny, <5 minutes*