### PR TITLE
fix: NPM publish only triggers on main branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches:
+      - "main" # Only trigger for main branch
 
 jobs:
   lint:


### PR DESCRIPTION
# Problem

Fixes a bug where the NPM publish action could run any branch with a matching tag.

*Estimated review size: tiny, <5 minutes*
