### PR TITLE
Cache uncompressed chunks

### DIFF
--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -1,7 +1,7 @@
 import { Chunk, DataType } from "@zarrita/core";
 
 type MaybeCacheEntry = CacheEntry | null;
-type CacheData = ArrayBuffer | Chunk<DataType>;
+export type CacheData = ArrayBuffer | Chunk<DataType>;
 type CacheEntry = {
   /** The data contained in this entry */
   data: CacheData;

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -1,5 +1,7 @@
 import { Chunk, DataType } from "@zarrita/core";
 
+export const isChunk = (data: CacheData): data is Chunk<DataType> => (data as Chunk<DataType>).data !== undefined;
+
 type MaybeCacheEntry = CacheEntry | null;
 export type CacheData = ArrayBuffer | Chunk<DataType>;
 type CacheEntry = {

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -1,7 +1,5 @@
 import { Chunk, DataType } from "@zarrita/core";
 
-export const isChunk = (data: CacheData): data is Chunk<DataType> => (data as Chunk<DataType>).data !== undefined;
-
 type MaybeCacheEntry = CacheEntry | null;
 export type CacheData = ArrayBuffer | Chunk<DataType>;
 type CacheEntry = {
@@ -14,6 +12,8 @@ type CacheEntry = {
   /** The key which indexes this entry */
   key: string;
 };
+
+export const isChunk = (data: CacheData): data is Chunk<DataType> => (data as Chunk<DataType>).data !== undefined;
 
 const dataSize = (data: CacheData): number =>
   (data as ArrayBuffer).byteLength ?? (data as Chunk<DataType>).data.byteLength;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -8,7 +8,7 @@ import {
 } from "./IVolumeLoader.js";
 import { computeAtlasSize, type ImageInfo } from "../ImageInfo.js";
 import type { VolumeDims } from "../VolumeDims.js";
-import VolumeCache from "../VolumeCache.js";
+import VolumeCache, { isChunk } from "../VolumeCache.js";
 import type { TypedArray, NumberType } from "../types.js";
 import { getDataRange } from "../utils/num_utils.js";
 
@@ -260,7 +260,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
       for (let j = 0; j < Math.min(image.channels.length, 4); ++j) {
         const chindex = image.channels[j];
         const cacheResult = cache?.get(`${image.name}/${chindex}`);
-        if (cacheResult) {
+        if (cacheResult && !isChunk(cacheResult)) {
           // all data coming from this loader is natively 8-bit
           const channelData = new Uint8Array(cacheResult);
           if (syncChannels) {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -454,6 +454,10 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
   /** Reads a list of chunk keys requested by a `loadVolumeData` call and sets up appropriate prefetch requests. */
   private beginPrefetch(keys: ZarrChunkFetchInfo[], scaleLevel: number): void {
     // Convert keys to arrays of coords
+    if (keys.length === 0) {
+      return;
+    }
+
     const chunkCoords = keys.map(({ sourceIdx, key }) => {
       const numDims = getDimensionCount(this.sources[sourceIdx].axesTCZYX);
       const coordsInDimensionOrder = key

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -44,6 +44,7 @@ import type {
   NumericZarrArray,
 } from "./zarr_utils/types.js";
 import { VolumeLoadError, VolumeLoadErrorType, wrapVolumeLoadError } from "./VolumeLoadError.js";
+import cachingArray from "./zarr_utils/CachingArray.js";
 import { validateOMEZarrMetadata } from "./zarr_utils/validation.js";
 
 const CHUNK_REQUEST_CANCEL_REASON = "chunk request cancelled";
@@ -169,7 +170,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
 
     // Create one `ZarrSource` per URL
     const sourceProms = urlsArr.map(async (url, i) => {
-      const store = new WrappedStore<RequestInit>(new FetchStore(url), cache, queue);
+      const store = new WrappedStore<RequestInit>(new FetchStore(url), queue);
       const root = zarr.root(store);
 
       const group = await zarr
@@ -191,6 +192,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       const lvlProms = multiscaleMetadata.datasets.map(({ path }) =>
         zarr
           .open(root.resolve(path), { kind: "array" })
+          .then((array) => (cache ? cachingArray(array, cache) : array))
           .catch(
             wrapVolumeLoadError(
               `Failed to open scale level ${path} of OME-Zarr data at ${url}`,

--- a/src/loaders/zarr_utils/CachingArray.ts
+++ b/src/loaders/zarr_utils/CachingArray.ts
@@ -1,9 +1,7 @@
 import { Array as ZarrArray, Chunk, DataType } from "@zarrita/core";
-import VolumeCache, { CacheData } from "../../VolumeCache";
+import VolumeCache, { isChunk } from "../../VolumeCache";
 import { Readable } from "@zarrita/storage";
 import { pathIsToMetadata } from "./utils";
-
-const isChunk = (data: CacheData): data is Chunk<DataType> => (data as Chunk<DataType>).data !== undefined;
 
 export default function cachingArray<T extends DataType, Store extends Readable = Readable>(
   array: ZarrArray<T, Store>,

--- a/src/loaders/zarr_utils/CachingArray.ts
+++ b/src/loaders/zarr_utils/CachingArray.ts
@@ -27,6 +27,19 @@ export default function cachingArray<T extends DataType, Store extends Readable 
   };
 
   return new Proxy(array, {
-    get: (target, prop, reciever) => (prop === "getChunk" ? getChunk : Reflect.get(target, prop, reciever)),
+    get: (target, prop) => {
+      if (prop === "getChunk") {
+        return getChunk;
+      }
+
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#no_private_property_forwarding
+      const value = target[prop];
+      if (value instanceof Function) {
+        return function (...args: unknown[]) {
+          return value.apply(target, args);
+        };
+      }
+      return value;
+    },
   });
 }

--- a/src/loaders/zarr_utils/CachingArray.ts
+++ b/src/loaders/zarr_utils/CachingArray.ts
@@ -1,6 +1,7 @@
 import { Array as ZarrArray, Chunk, DataType } from "@zarrita/core";
-import VolumeCache, { isChunk } from "../../VolumeCache";
 import { Readable } from "@zarrita/storage";
+
+import VolumeCache, { isChunk } from "../../VolumeCache";
 import { pathIsToMetadata } from "./utils";
 
 export default function cachingArray<T extends DataType, Store extends Readable = Readable>(

--- a/src/loaders/zarr_utils/CachingArray.ts
+++ b/src/loaders/zarr_utils/CachingArray.ts
@@ -1,6 +1,7 @@
 import { Array, ArrayMetadata, Chunk, DataType } from "@zarrita/core";
 import VolumeCache, { CacheData } from "../../VolumeCache";
 import { AbsolutePath, Readable } from "@zarrita/storage";
+import { pathIsToMetadata } from "./utils";
 
 const ZARR_EXTS = [".zarray", ".zgroup", ".zattrs", "zarr.json"];
 
@@ -12,7 +13,7 @@ export default class CachingArray<T extends DataType, Store extends Readable = R
   }
 
   async getChunk(coords: number[], opts?: Parameters<Store["get"]>[1]): Promise<Chunk<T>> {
-    if (!this.cache || ZARR_EXTS.some((s) => this.path.endsWith(s))) {
+    if (!this.cache || pathIsToMetadata(this.path)) {
       return super.getChunk(coords, opts);
     }
 

--- a/src/loaders/zarr_utils/CachingArray.ts
+++ b/src/loaders/zarr_utils/CachingArray.ts
@@ -1,31 +1,32 @@
-import { Array, ArrayMetadata, Chunk, DataType } from "@zarrita/core";
+import { Array as ZarrArray, Chunk, DataType } from "@zarrita/core";
 import VolumeCache, { CacheData } from "../../VolumeCache";
-import { AbsolutePath, Readable } from "@zarrita/storage";
+import { Readable } from "@zarrita/storage";
 import { pathIsToMetadata } from "./utils";
-
-const ZARR_EXTS = [".zarray", ".zgroup", ".zattrs", "zarr.json"];
 
 const isChunk = (data: CacheData): data is Chunk<DataType> => (data as Chunk<DataType>).data !== undefined;
 
-export default class CachingArray<T extends DataType, Store extends Readable = Readable> extends Array<T, Store> {
-  constructor(store: Store, path: AbsolutePath, metadata: ArrayMetadata<T>, private cache?: VolumeCache) {
-    super(store, path, metadata);
-  }
-
-  async getChunk(coords: number[], opts?: Parameters<Store["get"]>[1]): Promise<Chunk<T>> {
-    if (!this.cache || pathIsToMetadata(this.path)) {
-      return super.getChunk(coords, opts);
+export default function cachingArray<T extends DataType, Store extends Readable = Readable>(
+  array: ZarrArray<T, Store>,
+  cache: VolumeCache
+): ZarrArray<T, Store> {
+  const getChunk = async (coords: number[], opts?: Parameters<Store["get"]>[1]): Promise<Chunk<T>> => {
+    if (pathIsToMetadata(array.path)) {
+      return array.getChunk(coords, opts);
     }
 
-    const trailingSlash = this.path.endsWith("/") ? "" : "/";
-    const fullKey = this.path + trailingSlash + coords.join(",");
-    const cacheResult = this.cache.get(fullKey);
+    const trailingSlash = array.path.endsWith("/") ? "" : "/";
+    const fullKey = array.path + trailingSlash + coords.join(",");
+    const cacheResult = cache.get(fullKey);
     if (cacheResult && isChunk(cacheResult)) {
       return cacheResult;
     }
 
-    const result = await super.getChunk(coords, opts);
-    this.cache.insert(fullKey, result);
+    const result = await array.getChunk(coords, opts);
+    cache.insert(fullKey, result);
     return result;
-  }
+  };
+
+  return new Proxy(array, {
+    get: (target, prop, reciever) => (prop === "getChunk" ? getChunk : Reflect.get(target, prop, reciever)),
+  });
 }

--- a/src/loaders/zarr_utils/CachingArray.ts
+++ b/src/loaders/zarr_utils/CachingArray.ts
@@ -1,0 +1,30 @@
+import { Array, ArrayMetadata, Chunk, DataType } from "@zarrita/core";
+import VolumeCache, { CacheData } from "../../VolumeCache";
+import { AbsolutePath, Readable } from "@zarrita/storage";
+
+const ZARR_EXTS = [".zarray", ".zgroup", ".zattrs", "zarr.json"];
+
+const isChunk = (data: CacheData): data is Chunk<DataType> => (data as Chunk<DataType>).data !== undefined;
+
+export default class CachingArray<T extends DataType, Store extends Readable = Readable> extends Array<T, Store> {
+  constructor(store: Store, path: AbsolutePath, metadata: ArrayMetadata<T>, private cache?: VolumeCache) {
+    super(store, path, metadata);
+  }
+
+  async getChunk(coords: number[], opts?: Parameters<Store["get"]>[1]): Promise<Chunk<T>> {
+    if (!this.cache || ZARR_EXTS.some((s) => this.path.endsWith(s))) {
+      return super.getChunk(coords, opts);
+    }
+
+    const trailingSlash = this.path.endsWith("/") ? "" : "/";
+    const fullKey = this.path + trailingSlash + coords.join(",");
+    const cacheResult = this.cache.get(fullKey);
+    if (cacheResult && isChunk(cacheResult)) {
+      return cacheResult;
+    }
+
+    const result = await super.getChunk(coords, opts);
+    this.cache.insert(fullKey, result);
+    return result;
+  }
+}

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -65,6 +65,13 @@ export default class ChunkPrefetchIterator {
       updateMinMax(chunk[4], extrema[3]);
     }
 
+    // Bail out if we have any non-finite values in the extrema (the iterator will be empty)
+    if (extrema.flat().some((val) => !Number.isFinite(val))) {
+      this.directionStates = [];
+      this.priorityDirectionStates = [];
+      return;
+    }
+
     // Create `PrefetchDirectionState`s for each direction
     this.directionStates = [];
     this.priorityDirectionStates = [];

--- a/src/loaders/zarr_utils/WrappedStore.ts
+++ b/src/loaders/zarr_utils/WrappedStore.ts
@@ -2,9 +2,9 @@ import { FetchStore } from "zarrita";
 import { AbsolutePath, AsyncMutable, Readable } from "@zarrita/storage";
 
 import SubscribableRequestQueue from "../../utils/SubscribableRequestQueue";
-import VolumeCache from "../../VolumeCache";
 
 import { SubscriberId } from "./types";
+import { pathIsToMetadata } from "./utils";
 
 type WrappedStoreOpts<Opts> = {
   options?: Opts;
@@ -15,26 +15,17 @@ type WrappedStoreOpts<Opts> = {
 
 /**
  * `Readable` is zarrita's minimal abstraction for any source of data.
- * `WrappedStore` wraps another `Readable` and adds (optional) connections to `VolumeCache` and `RequestQueue`.
+ * `WrappedStore` wraps another `Readable` and adds useful extras, notably an (optional) connection to `RequestQueue`
  */
 class WrappedStore<Opts, S extends Readable<Opts> = Readable<Opts>> implements AsyncMutable<WrappedStoreOpts<Opts>> {
-  constructor(private baseStore: S, private cache?: VolumeCache, private queue?: SubscribableRequestQueue) {}
+  constructor(private baseStore: S, private queue?: SubscribableRequestQueue) {}
   // Dummy implementation to make this class easier to use in tests
   set(_key: AbsolutePath, _value: Uint8Array): Promise<void> {
     return Promise.resolve();
   }
 
-  private async getAndCache(key: AbsolutePath, cacheKey: string, opts?: Opts): Promise<Uint8Array | undefined> {
-    const result = await this.baseStore.get(key, opts);
-    if (this.cache && result) {
-      this.cache.insert(cacheKey, result);
-    }
-    return result;
-  }
-
   async get(key: AbsolutePath, opts?: WrappedStoreOpts<Opts> | undefined): Promise<Uint8Array | undefined> {
-    const ZARR_EXTS = [".zarray", ".zgroup", ".zattrs", "zarr.json"];
-    if (!this.cache || ZARR_EXTS.some((s) => key.endsWith(s))) {
+    if (pathIsToMetadata(key)) {
       return this.baseStore.get(key, opts?.options);
     }
     if (opts?.reportKey) {
@@ -48,23 +39,17 @@ class WrappedStore<Opts, S extends Readable<Opts> = Readable<Opts>> implements A
 
     const fullKey = keyPrefix + key.slice(1);
 
-    // Check the cache
-    const cacheResult = this.cache.get(fullKey);
-    if (cacheResult) {
-      return new Uint8Array(cacheResult);
-    }
-
     // Not in cache; load the chunk and cache it
     if (this.queue && opts) {
       return this.queue.addRequest(
         fullKey,
         opts.subscriber,
-        () => this.getAndCache(key, fullKey, opts?.options),
+        async () => this.baseStore.get(key, opts?.options),
         opts.isPrefetch
       );
     } else {
       // Should we ever hit this code?  We should always have a request queue.
-      return this.getAndCache(key, fullKey, opts?.options);
+      return this.baseStore.get(key, opts?.options);
     }
   }
 }

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -18,6 +18,9 @@ export function getSourceChannelNames(src: ZarrSource): string[] {
   return Array.from({ length }, (_, idx) => `Channel ${idx + src.channelOffset}`);
 }
 
+const META_FILENAMES = [".zarray", ".zgroup", ".zattrs", "zarr.json"];
+export const pathIsToMetadata = (path: string): boolean => META_FILENAMES.some((s) => path.endsWith(s));
+
 /** Turns `axesTCZYX` into the number of dimensions in the array */
 export const getDimensionCount = ([t, c, z]: TCZYX<number>) => 2 + Number(t > -1) + Number(c > -1) + Number(z > -1);
 


### PR DESCRIPTION
Review time: small-medium (~15-20min)

# Problem

Closes #264: moves OME-Zarr chunk caching from before chunks are decompressed to after, making playback of cached time series volumes significantly faster!

# Quick background

zarrita.js, the library we use to read zarr datasets, has a few important abstraction layers:
- `Store`s are the most basic &mdash; just a plain source of data keyed by strings
- `Array`s wrap `Store`s and add awareness of the individual sizes, shapes, chunking strategies, and (importantly) encodings of specific arrays. They allow querying single chunks by their coordinates.
- The `get` function from `@zarrita/indexing` accepts an `Array` and can extract an arbitrary subset of data from it, by querying many chunks and assembling data from them into a larger typed array.

Our previous strategy for adding caching slotted in between the `Store` and the `Array`, where chunks were not yet decoded. To cache decoded data, we instead need to get between the `Array` and the indexing function.

# Solution

This PR removes the cache connection in `WrappedStore` (that object sticks around to queue requests, though zarrita has a place for a queue in the indexing function, so `WrappedStore` could now go away entirely in a future cleanup PR?) and introduces a function called `cachingArray`, which connects an `Array` to the cache. This works via an ES `Proxy` object, which is a bit awkward, but seemed to be the least bad option:

- Extending the `Array` class wasn't great because arrays are mainly produced by methods on other objects from zarrita, not their own constructors, and we can't make those methods create instances of our special custom extended array instead
- Creating a wrapper class with exactly the same interface as the base `Array` class would have involved a lot of boilerplate and been more vulnerable to interface changes later down the line
- Proxies have a bit of subtlety when [combined with objects with private fields](https://lea.verou.me/blog/2023/04/private-fields-considered-harmful/), but this can be worked around for this case

This PR also adds some additional guardrails around a possible infinite loop condition in our current prefetching implementation. Future work should try to make this more robust.

## Steps to Verify:

1. Select a volume with a time series (e.g. "OME-Zarr (NucMorph)").
2. Play through time a bit to get data into the cache.
3. Skip back to the beginning and play again. *This should be noticeably faster on this branch than on main.*
