### PR TITLE
Update zarrita to v0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "three": "^0.171.0",
         "throttled-queue": "^2.1.4",
         "tweakpane": "^3.1.9",
-        "zarrita": "^0.3.2"
+        "zarrita": "^0.4.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.25.6",
@@ -2790,39 +2790,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@zarrita/core": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
-      "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
-      "dependencies": {
-        "@zarrita/storage": "^0.0.2",
-        "@zarrita/typedarray": "^0.0.1",
-        "numcodecs": "^0.2.2"
-      }
-    },
-    "node_modules/@zarrita/indexing": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
-      "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
-      "dependencies": {
-        "@zarrita/core": "^0.0.3",
-        "@zarrita/storage": "^0.0.2",
-        "@zarrita/typedarray": "^0.0.1"
-      }
-    },
     "node_modules/@zarrita/storage": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
-      "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.0.tgz",
+      "integrity": "sha512-lSGDQik2fLt/UyvWzWd23sJFHckEmk50F9Baz2XlbgFQhvd2EVBcHGweOTBhu3c5SB05TzOnlY1M1i2FMDi6YA==",
+      "license": "MIT",
       "dependencies": {
         "reference-spec-reader": "^0.2.0",
-        "unzipit": "^1.3.6"
+        "unzipit": "^1.4.3"
       }
-    },
-    "node_modules/@zarrita/typedarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
-      "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -5500,7 +5476,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -8919,12 +8894,12 @@
       }
     },
     "node_modules/numcodecs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
-      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
       "license": "MIT",
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "fflate": "^0.8.0"
       }
     },
     "node_modules/nwsapi": {
@@ -13948,13 +13923,13 @@
       }
     },
     "node_modules/zarrita": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
-      "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.4.0.tgz",
+      "integrity": "sha512-MK2uustzUF0PooWl6HVUfTares/nmaq5NwRZux/L3npvkSX6Qdpd7w/NOW2cF9EI35yqggoHNi3Nlxyq1YT5eQ==",
+      "license": "MIT",
       "dependencies": {
-        "@zarrita/core": "^0.0.3",
-        "@zarrita/indexing": "^0.0.3",
-        "@zarrita/storage": "^0.0.2"
+        "@zarrita/storage": "^0.1.0",
+        "numcodecs": "^0.3.2"
       }
     },
     "node_modules/zstddec": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "three": "^0.171.0",
     "throttled-queue": "^2.1.4",
     "tweakpane": "^3.1.9",
-    "zarrita": "^0.3.2"
+    "zarrita": "^0.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.25.6",
@@ -74,8 +74,8 @@
     "typescript": "^4.3.5",
     "url-loader": "^4.1.1",
     "vite": "^6.0.6",
-    "vitest": "^2.1.8",
     "vite-plugin-glsl": "^1.3.1",
+    "vitest": "^2.1.8",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4"

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -1,4 +1,4 @@
-import { Chunk, DataType } from "@zarrita/core";
+import { Chunk, DataType } from "zarrita";
 
 type MaybeCacheEntry = CacheEntry | null;
 export type CacheData = ArrayBuffer | Chunk<DataType>;
@@ -15,8 +15,9 @@ type CacheEntry = {
 
 export const isChunk = (data: CacheData): data is Chunk<DataType> => (data as Chunk<DataType>).data !== undefined;
 
-const dataSize = (data: CacheData): number =>
-  (data as ArrayBuffer).byteLength ?? (data as Chunk<DataType>).data.byteLength;
+const chunkSize = ({ data }: Chunk<DataType>): number => (Array.isArray(data) ? data.length : data.byteLength);
+
+const dataSize = (data: CacheData): number => (data as ArrayBuffer).byteLength ?? chunkSize(data as Chunk<DataType>);
 
 /** Default: 250MB. Should be large enough to be useful but safe for most any computer that can run the app */
 const CACHE_MAX_SIZE_DEFAULT = 250_000_000;

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -1,10 +1,7 @@
 import { Box3, Vector3 } from "three";
 
-import * as zarr from "@zarrita/core";
-import { get as zarrGet, slice, Slice } from "@zarrita/indexing";
-// Importing `FetchStore` from its home subpackage (@zarrita/storage) causes errors.
-// Getting it from the top-level package means we don't get its type. This is also a bug, but it's more acceptable.
-import { FetchStore } from "zarrita";
+import * as zarr from "zarrita";
+const { slice } = zarr;
 
 import type { ImageInfo } from "../ImageInfo.js";
 import type { VolumeDims } from "../VolumeDims.js";
@@ -167,7 +164,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
 
     // Create one `ZarrSource` per URL
     const sourceProms = urlsArr.map(async (url, i) => {
-      const store = new FetchStore(url);
+      const store = new zarr.FetchStore(url);
       const root = zarr.root(store);
 
       const group = await zarr
@@ -562,16 +559,19 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       const unorderedSpec = [loadSpec.time, sourceCh, slice(min.z, max.z), slice(min.y, max.y), slice(min.x, max.x)];
 
       const level = this.sources[sourceIdx].scaleLevels[multiscaleLevel];
-      const sliceSpec = this.orderByDimension(unorderedSpec as TCZYX<number | Slice>, sourceIdx);
+      const sliceSpec = this.orderByDimension(unorderedSpec as TCZYX<number | zarr.Slice>, sourceIdx);
       const reportChunk = (coords: number[], sub: SubscriberId) => reportChunkBase(sourceIdx, coords, sub);
 
-      const result = await zarrGet(level, sliceSpec, { opts: { subscriber, reportChunk } }).catch(
-        wrapVolumeLoadError(
-          "Could not load OME-Zarr volume data",
-          VolumeLoadErrorType.LOAD_DATA_FAILED,
-          CHUNK_REQUEST_CANCEL_REASON
-        )
-      );
+      console.log(level);
+      const result = await zarr
+        .get(level, sliceSpec, { opts: { subscriber, reportChunk } })
+        .catch(
+          wrapVolumeLoadError(
+            "Could not load OME-Zarr volume data",
+            VolumeLoadErrorType.LOAD_DATA_FAILED,
+            CHUNK_REQUEST_CANCEL_REASON
+          )
+        );
 
       if (result?.data === undefined) {
         return;

--- a/src/loaders/VolumeLoadError.ts
+++ b/src/loaders/VolumeLoadError.ts
@@ -1,5 +1,5 @@
 import { errorConstructors } from "serialize-error";
-import { NodeNotFoundError, KeyError } from "@zarrita/core";
+import { NodeNotFoundError, KeyError } from "zarrita";
 // geotiff doesn't export its error types...
 
 /** Groups possible load errors into a few broad categories which we can give similar guidance to the user about. */

--- a/src/loaders/zarr_utils/types.ts
+++ b/src/loaders/zarr_utils/types.ts
@@ -1,4 +1,4 @@
-import * as zarr from "@zarrita/core";
+import * as zarr from "zarrita";
 import { AsyncReadable } from "@zarrita/storage";
 
 import type SubscribableRequestQueue from "../../utils/SubscribableRequestQueue.js";

--- a/src/loaders/zarr_utils/wrapArray.ts
+++ b/src/loaders/zarr_utils/wrapArray.ts
@@ -1,5 +1,4 @@
-import { Array as ZarrArray, type Chunk, type DataType } from "@zarrita/core";
-import type { AsyncReadable } from "@zarrita/storage";
+import type { Array as ZarrArray, AsyncReadable, Chunk, DataType } from "zarrita";
 
 import VolumeCache, { isChunk } from "../../VolumeCache.js";
 import { pathIsToMetadata } from "./utils.js";

--- a/src/test/RequestQueue.test.ts
+++ b/src/test/RequestQueue.test.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 
 import { Vector3 } from "three";
-import { TypedArray } from "@zarrita/core";
+import type { TypedArray } from "zarrita";
 
 import RequestQueue, { Request } from "../utils/RequestQueue";
 import { LoadSpec, loadSpecToString } from "../loaders/IVolumeLoader";

--- a/src/test/zarr_utils.test.ts
+++ b/src/test/zarr_utils.test.ts
@@ -1,5 +1,5 @@
-import type { AbsolutePath, AsyncReadable, AsyncWriteable } from "@zarrita/storage";
-import * as zarr from "@zarrita/core";
+import type { AbsolutePath, AsyncReadable, AsyncWritable } from "zarrita";
+import * as zarr from "zarrita";
 
 import {
   NumericZarrArray,
@@ -54,7 +54,7 @@ const createMockMultiscaleMetadata = (scales: number[][], paths?: string[]): OME
   })),
 });
 
-class MockStore implements AsyncReadable, AsyncWriteable {
+class MockStore implements AsyncReadable, AsyncWritable {
   async set(_key: AbsolutePath, _value: Uint8Array): Promise<void> {
     return undefined;
   }


### PR DESCRIPTION
Review time: small (~5min)

Updates to zarrita's [new v0.4 release](https://github.com/manzt/zarrita.js/releases/tag/zarrita%400.4.0). This release deletes a number of subpackages from which we were explicitly importing, while seemingly resolving the errors that motivated us to import from the subpackages in the first place. So a lot of imports have changed, but not much else is different here.

This release also seems to fix the remaining errors which were preventing us from loading Zarr v3 (and therefore OME-Zarr v0.5) datasets, and therefore resolves #263. To verify:
- in this repo: `npm i`; `npm run build`; `npm link`
- in vole-app: `npm link @aics/vole-core`; `npm start`
- open http://localhost:9020/viewer?url=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.5/6001240.zarr