### PR TITLE
feat: Added support for synchronous operations (render + setTime)

### DIFF
--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -146,6 +146,10 @@ export class View3d {
     return this.canvas3d.containerdiv;
   }
 
+  getCanvasDOMElement(): HTMLCanvasElement {
+    return this.canvas3d.renderer.domElement;
+  }
+
   getCameraState(): CameraState {
     return this.canvas3d.getCameraState();
   }
@@ -160,6 +164,10 @@ export class View3d {
    */
   redraw(): void {
     this.canvas3d.redraw();
+  }
+
+  render(): void {
+    this.canvas3d.render();
   }
 
   unsetImage(): VolumeDrawable | undefined {
@@ -259,10 +267,11 @@ export class View3d {
     this.loadErrorHandler = handler;
   }
 
-  setTime(volume: Volume, time: number, onChannelLoaded?: PerChannelCallback): void {
+  async setTime(volume: Volume, time: number, onChannelLoaded?: PerChannelCallback): Promise<void> {
     const timeClamped = Math.max(0, Math.min(time, volume.imageInfo.times - 1));
-    volume.updateRequiredData({ time: timeClamped }, onChannelLoaded);
+    const loadPromise = volume.updateRequiredData({ time: timeClamped }, onChannelLoaded);
     this.updateTimestepIndicator(volume);
+    await loadPromise;
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -270,7 +270,7 @@ export class View3d {
     this.loadErrorHandler = handler;
   }
 
-  async setTime(volume: Volume, time: number, onChannelLoaded?: PerChannelCallback): Promise<void> {
+  setTime(volume: Volume, time: number, onChannelLoaded?: PerChannelCallback): Promise<void> {
     const timeClamped = Math.max(0, Math.min(time, volume.imageInfo.times - 1));
     const loadPromise = volume.updateRequiredData({ time: timeClamped }, onChannelLoaded);
     this.updateTimestepIndicator(volume);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -161,13 +161,16 @@ export class View3d {
 
   /**
    * Force a redraw.
+   * @param synchronous If true, the redraw will be done synchronously. If false (default), the
+   * redraw will be done asynchronously via `requestAnimationFrame`. Redraws should be done async
+   * whenever possible for the best performance.
    */
-  redraw(): void {
-    this.canvas3d.redraw();
-  }
-
-  render(): void {
-    this.canvas3d.render();
+  redraw(synchronous: boolean = false): void {
+    if (synchronous) {
+      this.canvas3d.onAnimationLoop();
+    } else {
+      this.canvas3d.redraw();
+    }
   }
 
   unsetImage(): VolumeDrawable | undefined {
@@ -271,7 +274,7 @@ export class View3d {
     const timeClamped = Math.max(0, Math.min(time, volume.imageInfo.times - 1));
     const loadPromise = volume.updateRequiredData({ time: timeClamped }, onChannelLoaded);
     this.updateTimestepIndicator(volume);
-    await loadPromise;
+    return loadPromise;
   }
 
   /**

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -176,7 +176,7 @@ export default class Volume {
     }
 
     if (shouldReload) {
-      this.loadNewData(onChannelLoaded);
+      await this.loadNewData(onChannelLoaded);
     }
   }
 


### PR DESCRIPTION
# Problem

TFE is now using `vole-core`, but it requires some operations to be synchronous.

During an export operation, TFE will asynchronously request a frame load for each frame in a video. Once the frame load Promise resolves, TFE's exporter expects that it can synchronously call `render()` on the canvas, and then immediately get the canvas image and save it to the video buffer. 

Currently, the only access to rendering is via the `redraw()` function on `View3d`, which hooks into the asynchronous `requestAnimationFrame` loop. Additionally, `setTime` is not asynchronous either, which is necessary for both time playback and for Export support.

*Estimated review size: tiny, <5 minutes*

# Solution

- Changed `setTime` to return a `Promise` that resolves once a frame is loaded.
- Added access to synchronous rendering with `renderer.render()`.
- Added a new `getCanvasDOMElement` method for directly getting the `canvas` that the renderer is rendering to. 

## Type of change

- New feature (non-breaking change which adds functionality)

