### PR TITLE
feat: Added support for per-frame ID offsets during colorizing

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -971,8 +971,7 @@ function onVolumeCreated(name: string, volume: Volume) {
   // hardcoded a special volume to know it's segmentation channel for pick testing
   if (name === "testpick") {
     view3D.enablePicking(myState.volume, true, 0);
-  }
-  else {
+  } else {
     view3D.enablePicking(myState.volume, false);
   }
 
@@ -1182,7 +1181,8 @@ function getStateColorizeFeature(): ColorizeFeature | null {
       outOfRangeColor: new Color(0x444444),
       outlierDrawMode: 0,
       outOfRangeDrawMode: 0,
-      hideOutOfRange: false
+      hideOutOfRange: false,
+      timeToIdOffset: new Uint32Array([0]),
     };
   } else {
     return null;

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -49,6 +49,7 @@ export default class Channel {
   public lutTexture: DataTexture;
   public rawMin: number;
   public rawMax: number;
+  public time: number;
 
   constructor(name: string) {
     this.loaded = false;
@@ -56,6 +57,7 @@ export default class Channel {
     this.imgData = { data: new Uint8Array(), width: 0, height: 0 };
     this.rawMin = 0;
     this.rawMax = 255;
+    this.time = 0;
 
     // on gpu
     this.dataTexture = new DataTexture(new Uint8Array(), 0, 0);
@@ -224,7 +226,8 @@ export default class Channel {
     dtype: NumberType,
     rawMin: number,
     rawMax: number,
-    subregionSize: Vector3
+    subregionSize: Vector3,
+    time = 0
   ): void {
     this.dtype = dtype;
     this.imgData = { data: bitsArray, width: w, height: h };
@@ -233,6 +236,7 @@ export default class Channel {
 
     this.loaded = true;
     this.histogram = new Histogram(bitsArray);
+    this.time = time;
 
     // reuse old lut but auto-remap it to new data range
     this.setRawDataRange(rawMin, rawMax);
@@ -284,11 +288,13 @@ export default class Channel {
     ay: number,
     rawMin: number,
     rawMax: number,
-    dtype: NumberType
+    dtype: NumberType,
+    time = 0
   ): void {
     this.dims = [vx, vy, vz];
     this.volumeData = bitsArray;
     this.dtype = dtype;
+    this.time = time;
     // TODO FIXME performance hit for shuffling the data and storing 2 versions of it (could do this in worker at least?)
     this.packToAtlas(vx, vy, vz, ax, ay);
     this.loaded = true;

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -237,22 +237,23 @@ export default class FusedChannelData {
         const mat = this.getShader(channels[chIndex].dtype, isColorize).clone();
         mat.uniforms.srcTexture.value = channels[chIndex].dataTexture;
         mat.uniforms.highlightedId.value = combination[i].selectedID == undefined ? -1 : combination[i].selectedID;
-        if (isColorize) {
-          mat.uniforms.featureData.value = combination[i].feature?.idsToFeatureValue;
-          mat.uniforms.outlierData.value = combination[i].feature?.outlierData;
-          mat.uniforms.inRangeIds.value = combination[i].feature?.inRangeIds;
-          mat.uniforms.featureColorRampMin.value = combination[i].feature?.featureMin;
-          mat.uniforms.featureColorRampMax.value = combination[i].feature?.featureMax;
-          mat.uniforms.colorRamp.value = combination[i].feature?.featureValueToColor;
-          mat.uniforms.outlineColor.value = combination[i].feature?.outlineColor;
-          mat.uniforms.outlierColor.value = combination[i].feature?.outlierColor;
-          mat.uniforms.outOfRangeColor.value = combination[i].feature?.outOfRangeColor;
-          mat.uniforms.outlierDrawMode.value = combination[i].feature?.outlierDrawMode;
-          mat.uniforms.outOfRangeDrawMode.value = combination[i].feature?.outOfRangeDrawMode;
-          mat.uniforms.hideOutOfRange.value = combination[i].feature?.hideOutOfRange;
+        const feature = combination[i].feature;
+        if (isColorize && feature) {
+          mat.uniforms.featureData.value = feature.idsToFeatureValue;
+          mat.uniforms.outlierData.value = feature.outlierData;
+          mat.uniforms.inRangeIds.value = feature.inRangeIds;
+          mat.uniforms.featureColorRampMin.value = feature.featureMin;
+          mat.uniforms.featureColorRampMax.value = feature.featureMax;
+          mat.uniforms.colorRamp.value = feature.featureValueToColor;
+          mat.uniforms.outlineColor.value = feature.outlineColor;
+          mat.uniforms.outlierColor.value = feature.outlierColor;
+          mat.uniforms.outOfRangeColor.value = feature.outOfRangeColor;
+          mat.uniforms.outlierDrawMode.value = feature.outlierDrawMode;
+          mat.uniforms.outOfRangeDrawMode.value = feature.outOfRangeDrawMode;
+          mat.uniforms.hideOutOfRange.value = feature.hideOutOfRange;
           // Offset IDs based on the current frame, for data without
           // globally-unique IDs.
-          const idOffset = combination[i].feature?.timeToIdOffset[combination[i].time ?? 0] ?? 0;
+          const idOffset = feature.timeToIdOffset[channels[chIndex].time] ?? 0;
           mat.uniforms.idOffset.value = idOffset;
         } else {
           // the lut texture is spanning only the data range of the channel, not the datatype range

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -150,6 +150,7 @@ export default class FusedChannelData {
         outlierDrawMode: { value: 0 },
         outOfRangeDrawMode: { value: 0 },
         hideOutOfRange: { value: false },
+        idOffset: { value: 0 },
       },
       fragmentShader: fragShaderSrc,
       ...this.fuseMaterialProps,
@@ -249,6 +250,10 @@ export default class FusedChannelData {
           mat.uniforms.outlierDrawMode.value = combination[i].feature?.outlierDrawMode;
           mat.uniforms.outOfRangeDrawMode.value = combination[i].feature?.outOfRangeDrawMode;
           mat.uniforms.hideOutOfRange.value = combination[i].feature?.hideOutOfRange;
+          // Offset IDs based on the current frame, for data without
+          // globally-unique IDs.
+          const idOffset = combination[i].feature?.timeToIdOffset[combination[i].time ?? 0] ?? 0;
+          mat.uniforms.idOffset.value = idOffset;
         } else {
           // the lut texture is spanning only the data range of the channel, not the datatype range
           mat.uniforms.lutMinMax.value = new Vector2(channels[chIndex].rawMin, channels[chIndex].rawMax);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -253,6 +253,9 @@ export class View3d {
   onVolumeData(volume: Volume, channels: number[]): void {
     this.image?.updateScale();
     this.image?.onChannelLoaded(channels);
+    for (const channel of channels) {
+      this.image?.setChannelTime(channel, volume.loadSpec.time);
+    }
     if (volume.isLoaded() && this.tweakpane) {
       this.tweakpane.refresh();
     }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -253,9 +253,6 @@ export class View3d {
   onVolumeData(volume: Volume, channels: number[]): void {
     this.image?.updateScale();
     this.image?.onChannelLoaded(channels);
-    for (const channel of channels) {
-      this.image?.setChannelTime(channel, volume.loadSpec.time);
-    }
     if (volume.isLoaded() && this.tweakpane) {
       this.tweakpane.refresh();
     }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -274,7 +274,7 @@ export default class Volume {
     atlasheight: number,
     range: [number, number],
     dtype: NumberType = "uint8",
-    time: number = 0
+    time = 0
   ): void {
     this.channels[channelIndex].setFromAtlas(
       atlasdata,
@@ -300,7 +300,7 @@ export default class Volume {
     volumeData: TypedArray<NumberType>,
     range: [number, number],
     dtype: NumberType = "uint8",
-    time: number = 0
+    time = 0
   ): void {
     const { subregionSize, atlasTileDims } = this.imageInfo;
     this.channels[channelIndex].setFromVolumeData(

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -273,7 +273,8 @@ export default class Volume {
     atlaswidth: number,
     atlasheight: number,
     range: [number, number],
-    dtype: NumberType = "uint8"
+    dtype: NumberType = "uint8",
+    time: number = 0
   ): void {
     this.channels[channelIndex].setFromAtlas(
       atlasdata,
@@ -282,7 +283,8 @@ export default class Volume {
       dtype,
       range[0],
       range[1],
-      this.imageInfo.subregionSize
+      this.imageInfo.subregionSize,
+      time
     );
     this.onChannelLoaded([channelIndex]);
   }
@@ -297,7 +299,8 @@ export default class Volume {
     channelIndex: number,
     volumeData: TypedArray<NumberType>,
     range: [number, number],
-    dtype: NumberType = "uint8"
+    dtype: NumberType = "uint8",
+    time: number = 0
   ): void {
     const { subregionSize, atlasTileDims } = this.imageInfo;
     this.channels[channelIndex].setFromVolumeData(
@@ -309,7 +312,8 @@ export default class Volume {
       atlasTileDims.y * subregionSize.y,
       range[0],
       range[1],
-      dtype
+      dtype,
+      time
     );
     this.onChannelLoaded([channelIndex]);
   }

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -79,6 +79,7 @@ export default class VolumeDrawable {
       return {
         chIndex: index,
         lut: new Uint8Array(LUT_ARRAY_LENGTH),
+        time: this.volume.loadSpecRequired.time,
         rgbColor: rgbColor,
         selectedID: -1,
       };
@@ -433,8 +434,7 @@ export default class VolumeDrawable {
         this.pickRendering = new PickVolume(this.volume, this.settings);
       }
       this.pickRendering.setChannelToPick(channelIndex);
-    }
-    else {
+    } else {
       this.pickRendering?.cleanup();
       this.pickRendering = undefined;
     }
@@ -469,6 +469,13 @@ export default class VolumeDrawable {
       }
     }
     return false;
+  }
+
+  setChannelTime(channelIndex: number, time: number): void {
+    if (!this.fusion[channelIndex]) {
+      return;
+    }
+    this.fusion[channelIndex].time = time;
   }
 
   fuse(): void {
@@ -542,7 +549,6 @@ export default class VolumeDrawable {
 
   onChannelAdded(newChannelIndex: number): void {
     this.channelColors[newChannelIndex] = this.volume.channelColorsDefault[newChannelIndex];
-
     this.fusion[newChannelIndex] = {
       chIndex: newChannelIndex,
       lut: new Uint8Array[LUT_ARRAY_LENGTH](),

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -471,13 +471,6 @@ export default class VolumeDrawable {
     return false;
   }
 
-  setChannelTime(channelIndex: number, time: number): void {
-    if (!this.fusion[channelIndex]) {
-      return;
-    }
-    this.fusion[channelIndex].time = time;
-  }
-
   fuse(): void {
     if (!this.volume) {
       return;

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -79,7 +79,6 @@ export default class VolumeDrawable {
       return {
         chIndex: index,
         lut: new Uint8Array(LUT_ARRAY_LENGTH),
-        time: this.volume.loadSpecRequired.time,
         rgbColor: rgbColor,
         selectedID: -1,
       };

--- a/src/constants/shaders/colorizeUI.frag
+++ b/src/constants/shaders/colorizeUI.frag
@@ -37,6 +37,13 @@ uniform bool hideOutOfRange;
 // src texture is the raw volume intensity data
 uniform usampler2D srcTexture;
 
+uint getId(ivec2 uv) {
+  uint rawId = texelFetch(srcTexture, uv, 0).r;
+  if (rawId == 0u) {
+    return 0u;
+  }
+  return rawId + idOffset;
+}
 vec4 getFloatFromTex(sampler2D tex, int index) {
   int width = textureSize(tex, 0).x;
   ivec2 featurePos = ivec2(index % width, index / width);
@@ -47,15 +54,6 @@ uvec4 getUintFromTex(usampler2D tex, int index) {
   ivec2 featurePos = ivec2(index % width, index / width);
   return texelFetch(tex, featurePos, 0);
 }
-
-uint getId(ivec2 uv) {
-  uint rawId = texelFetch(srcTexture, uv, 0).r;
-  if (rawId == 0u) {
-    return 0u;
-  }
-  return rawId + idOffset;
-}
-
 vec4 getColorRamp(float val) {
   float width = float(textureSize(colorRamp, 0).x);
   float range = (width - 1.0) / width;

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -179,10 +179,11 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
         const dtype = dtypes[i];
         const data = dataArrays[i];
         const range = ranges[i];
+        const time = volume.loadSpec.time;
         if (atlasDims) {
-          volume.setChannelDataFromAtlas(channelIndex, data, atlasDims[0], atlasDims[1], range, dtype);
+          volume.setChannelDataFromAtlas(channelIndex, data, atlasDims[0], atlasDims[1], range, dtype, time);
         } else {
-          volume.setChannelDataFromVolume(channelIndex, data, range, dtype);
+          volume.setChannelDataFromVolume(channelIndex, data, range, dtype, time);
         }
         onChannelLoaded?.(volume, channelIndex);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,8 @@ export interface ColorizeFeature {
    *
    * For each raw ID `i` at some time `t`, the global ID is `i +
    * timeToIdOffset[t]`.
+   *
+   * If raw IDs are globally-unique, this array should be all zeros.
    */
   timeToIdOffset: Uint32Array;
   inRangeIds: DataTexture;
@@ -87,7 +89,6 @@ export interface FuseChannel {
   selectedID: number;
   // if we are colorizing by feature, all the following inputs are needed
   feature?: ColorizeFeature;
-  time?: number;
 }
 
 /** If `FuseChannel.rgbColor` is this value, it is disabled from fusion. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,16 @@ export const ARRAY_CONSTRUCTORS = {
 export interface ColorizeFeature {
   idsToFeatureValue: DataTexture;
   featureValueToColor: DataTexture;
+  /**
+   * A mapping from the current frame number to the ID offset for that frame.
+   * This is used for data where the raw IDs are not globally-unique. Adding the
+   * offset to the raw ID gives the unique, global ID that can be used to index
+   * into the `idsToFeatureValue` and other colorize-related data textures.
+   *
+   * For each raw ID `i` at some time `t`, the global ID is `i +
+   * timeToIdOffset[t]`.
+   */
+  timeToIdOffset: Uint32Array;
   inRangeIds: DataTexture;
   outlierData: DataTexture;
   featureMin: number;
@@ -75,9 +85,9 @@ export interface FuseChannel {
   rgbColor: [number, number, number] | number;
   // the selected id will have its intensity auto-mapped to a pick color
   selectedID: number;
-
   // if we are colorizing by feature, all the following inputs are needed
   feature?: ColorizeFeature;
+  time?: number;
 }
 
 /** If `FuseChannel.rgbColor` is this value, it is disabled from fusion. */


### PR DESCRIPTION
# Problem

Adds support for https://github.com/allen-cell-animated/timelapse-colorizer/issues/551, "Support frame-local IDs (instead of global IDs only)".

TFE uses big arrays to hold feature, outlier, and other data. To look up data from these arrays, a segmentation has a globally-unique ID which it uses as the index. 

Previously, we also saved globally-unique IDs in our image data. However, ZARR segmentation files typically do NOT have globally-unique IDs, and are formatted so ID numbers start at 1 on each frame. To add compatibility for ZARR data, we have to offset from the raw IDs on each frame to get their global IDs.

*Estimated review size: small, 10-15 minutes*

# Solution

- Added the `timeToIdOffset` lookup in the `ColorizeFeature` colorizing params.
- FuseChannel now tracks the current loaded time of a volume, and uses it to passed an ID offset uniform to the fuse shader, 


## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots (optional):

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/68325096-f4af-490d-8af7-c461445dafa2



## Keyfiles
- `types.ts`
