### PR TITLE
feat: Added support for lookups from segmentation IDs to global IDs for sparse data

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -1,4 +1,4 @@
-import { Color, Vector3 } from "three";
+import { Color, DataTexture, Vector3 } from "three";
 import GUI from "lil-gui";
 
 import { colormaps as colorizercolormaps, features as colorizerfeatures } from "./colorizer";
@@ -1182,7 +1182,7 @@ function getStateColorizeFeature(): ColorizeFeature | null {
       outlierDrawMode: 0,
       outOfRangeDrawMode: 0,
       hideOutOfRange: false,
-      timeToIdOffset: new Uint32Array([0]),
+      frameToGlobalIdLookup: new Map(),
     };
   } else {
     return null;

--- a/public/index.ts
+++ b/public/index.ts
@@ -1,4 +1,4 @@
-import { Color, DataTexture, Vector3 } from "three";
+import { Color, Vector3 } from "three";
 import GUI from "lil-gui";
 
 import { colormaps as colorizercolormaps, features as colorizerfeatures } from "./colorizer";

--- a/src/constants/shaders/colorizeUI.frag
+++ b/src/constants/shaders/colorizeUI.frag
@@ -18,7 +18,7 @@ uniform usampler2D outlierData;
  * global ID (index in data buffers like `featureData` and `outlierData`).
  * 
  * For a given segmentation ID `segId`, the global ID is given by:
- * `segIdToGlobalId[segId - segIdOffset]`.
+ * `segIdToGlobalId[segId - segIdOffset] - 1`.
 */
 uniform usampler2D segIdToGlobalId;
 uniform uint segIdOffset;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,13 +57,19 @@ export interface ColorizeFeature {
   idsToFeatureValue: DataTexture;
   featureValueToColor: DataTexture;
   /**
-   * Maps from a frame number to an info object used to look up the global ID of
-   * a given segmentation ID (raw pixel value) on that frame. The info object
-   * contains a texture and a minimum segmentation ID for that frame, the latter
-   * of which is used to minimize the memory footprint of the lookup table.
+   * Maps from a frame number to an info object used to look up the global ID
+   * from a given segmentation ID (raw pixel value) on that frame. The info
+   * object contains a texture and a minimum segmentation ID for that frame, the
+   * latter of which is used to minimize the memory footprint of the lookup
+   * table.
    *
-   * For a frame at time `t`, the global ID of a segmentation `s` is given by:
-   * `lookup[t].texture.getAt(s - lookup[t].minSegId)`
+   * For a frame at time `t`, the global ID of a segmentation `segId` is given
+   * by:
+   * ```
+   * lookup[t].texture.getAt(segId - lookup[t].minSegId) - 1
+   * ```
+   * The result is `-1` if there is no global ID for that segmentation ID on
+   * that frame.
    *
    * The global ID can be used directly as an index into the
    * `idsToFeatureValue`, `inRangeIds`, and `outlierData` data textures to get

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,17 +57,19 @@ export interface ColorizeFeature {
   idsToFeatureValue: DataTexture;
   featureValueToColor: DataTexture;
   /**
-   * A mapping from the current frame number to the ID offset for that frame.
-   * This is used for data where the raw IDs are not globally-unique. Adding the
-   * offset to the raw ID gives the unique, global ID that can be used to index
-   * into the `idsToFeatureValue` and other colorize-related data textures.
+   * Maps from a frame number to an info object used to look up the global ID of
+   * a given segmentation ID (raw pixel value) on that frame. The info object
+   * contains a texture and a minimum segmentation ID for that frame, the latter
+   * of which is used to minimize the memory footprint of the lookup table.
    *
-   * For each raw ID `i` at some time `t`, the global ID is `i +
-   * timeToIdOffset[t]`.
+   * For a frame at time `t`, the global ID of a segmentation `s` is given by:
+   * `lookup[t].texture.getAt(s - lookup[t].minSegId)`
    *
-   * If raw IDs are globally-unique, this array should be all zeros.
+   * The global ID can be used directly as an index into the
+   * `idsToFeatureValue`, `inRangeIds`, and `outlierData` data textures to get
+   * values for that segmentation ID.
    */
-  timeToIdOffset: Uint32Array;
+  frameToGlobalIdLookup: Map<number, { texture: DataTexture; minSegId: number }>;
   inRangeIds: DataTexture;
   outlierData: DataTexture;
   featureMin: number;


### PR DESCRIPTION
# Problem

Supports https://github.com/allen-cell-animated/timelapse-colorizer/issues/630, "display data with arbitrary segmentation IDs."

This change removes a lot of the assumptions we were making about segmentation IDs in datasets. **The linked issue above has a better explanation of what this looks like.**

With the corresponding PR in TFE, this removes a requirement that all datasets be sorted by time and segmentation ID, and that segmentation IDs have to be monotonically increasing. It fixes a number of bugs in the preview EMT dataset as well that were caused by missing segmentation IDs.

*Estimated review size: small, <10 minutes*

# Solution

- Replaced the `frameToIdOffset` in `ColorizeFeature` with a new parameter, `frameToGlobalIdLookup`.
  - `frameToGlobalIdLookup` is a Map from frame numbers to an object containing a texture and an offset.
- Changed the shader to look up the global ID for each segmentation ID using the new uniforms.
- Fixed a bug where the highlighted ID was off-by-one.
- Added handling for segmentation IDs that have no corresponding global ID/no feature data.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots (optional):

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/ce7c3828-1c1f-4ceb-90ac-8c575b1ee145



