### PR TITLE
Handle zarrs without a channel dimension

### DIFF
--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -14,7 +14,8 @@ export function getSourceChannelNames(src: ZarrSource): string[] {
   if (src.omeroMetadata?.channels) {
     return src.omeroMetadata.channels.map(({ label }, idx) => label ?? `Channel ${idx + src.channelOffset}`);
   }
-  const length = src.scaleLevels[0].shape[src.axesTCZYX[1]];
+  const cIdx = src.axesTCZYX[1];
+  const length = cIdx < 0 ? 1 : src.scaleLevels[0].shape[cIdx];
   return Array.from({ length }, (_, idx) => `Channel ${idx + src.channelOffset}`);
 }
 


### PR DESCRIPTION
Review time: tiny <5min

OME-Zarr images without a notion of multiple channels may entirely lack metadata for describing the number and names of channels in the image. Currently, instead of treating these images as single-channel images, `OMEZarrLoader` effectively treats them as _zero-channel images_ and silently loads nothing. This PR adds a fallback for this kind of image.

This resolves the example given in #380. That issue incorrectly blames the image not loading on a "volume is too large" warning. But the example image mentioned in that issue should load with this fix: http://localhost:9020/viewer?url=https://janelia-cosem-datasets.s3.amazonaws.com/jrc_ccl81-covid-1/jrc_ccl81-covid-1.zarr/recon-1/em/fibsem-uint16//
