### PR TITLE
Remove `View3d.loaderContext` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ const loaderContext = new VolumeLoaderContext(CACHE_MAX_SIZE, CONCURRENCY_LIMIT,
 
 // create the viewer.  it will try to fill the parent element.
 const view3D = new View3d(el);
-view3D.loaderContext = loaderContext;
 
 // ensure the loader worker is ready
 await loaderContext.onOpen();

--- a/public/index.ts
+++ b/public/index.ts
@@ -1241,7 +1241,6 @@ function main() {
     return;
   }
   view3D = new View3d({ parentElement: el });
-  view3D.loaderContext = loaderContext;
 
   el.addEventListener("mousemove", (e: Event) => {
     const event = e as MouseEvent;

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -27,7 +27,7 @@ import {
 } from "./types.js";
 import { Axis } from "./VolumeRenderSettings.js";
 import { PerChannelCallback } from "./loaders/IVolumeLoader.js";
-import VolumeLoaderContext, { WorkerLoader } from "./workers/VolumeLoaderContext.js";
+import { WorkerLoader } from "./workers/VolumeLoaderContext.js";
 import Line3d from "./Line3d.js";
 
 // Constants are kept for compatibility reasons.
@@ -49,11 +49,6 @@ const allGlobalLoadingOptions = {
  * @class
  */
 export class View3d {
-  // TODO because View3d is basically a top level entrypoint for Vol-E,
-  // maybe it should create the VolumeLoaderContext with options passed in.
-  // (instead of having the loaderContext created externally)
-  public loaderContext?: VolumeLoaderContext;
-
   private canvas3d: ThreeJsPanel;
   private scene: Scene;
   private backgroundColor: Color;
@@ -1074,7 +1069,7 @@ export class View3d {
     });
     // when multiple prefetch frames arrive at once, should we slow down how quickly we load them?
     prefetch.addInput(allGlobalLoadingOptions, "throttleArrivingChannelData").on("change", (event) => {
-      this.loaderContext?.setThrottleChannelData(event.value);
+      loader?.getContext?.().setThrottleChannelData(event.value);
     });
 
     return pane;

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -1,4 +1,4 @@
-import { fromUrl } from "geotiff";
+import { fromUrl, type GeoTIFF, type GeoTIFFImage } from "geotiff";
 import { ErrorObject, deserializeError } from "serialize-error";
 
 import {
@@ -135,7 +135,7 @@ class TiffLoader extends ThreadableVolumeLoader {
 
   private async loadOmeDims(): Promise<OMEDims> {
     if (!this.dims) {
-      const tiff = await fromUrl(this.url, { allowFullFile: true }).catch(
+      const tiff = await fromUrl(this.url, { allowFullFile: true }).catch<GeoTIFF>(
         wrapVolumeLoadError(`Could not open TIFF file at ${this.url}`, VolumeLoadErrorType.NOT_FOUND)
       );
       // DO NOT DO THIS, ITS SLOW
@@ -143,7 +143,7 @@ class TiffLoader extends ThreadableVolumeLoader {
       // read the FIRST image
       const image = await tiff
         .getImage()
-        .catch(wrapVolumeLoadError("Failed to open TIFF image", VolumeLoadErrorType.NOT_FOUND));
+        .catch<GeoTIFFImage>(wrapVolumeLoadError("Failed to open TIFF image", VolumeLoadErrorType.NOT_FOUND));
 
       const tiffimgdesc = prepareXML(image.getFileDirectory().ImageDescription);
       const omeEl = getOME(tiffimgdesc);
@@ -260,7 +260,7 @@ class TiffLoader extends ThreadableVolumeLoader {
           url: this.url,
         };
 
-        const worker = new Worker(new URL("../workers/FetchTiffWorker", import.meta.url), {type: "module"});
+        const worker = new Worker(new URL("../workers/FetchTiffWorker", import.meta.url), { type: "module" });
         worker.onmessage = (e: MessageEvent<TiffLoadResult | { isError: true; error: ErrorObject }>) => {
           if (e.data.isError) {
             reject(deserializeError(e.data.error));

--- a/src/workers/VolumeLoaderContext.ts
+++ b/src/workers/VolumeLoaderContext.ts
@@ -217,7 +217,7 @@ class VolumeLoaderContext {
       throw new Error("Failed to create loader");
     }
 
-    const loader = new WorkerLoader(loaderId, this.workerHandle);
+    const loader = new WorkerLoader(loaderId, this.workerHandle, this);
     this.loaders.set(loaderId, loader);
     return loader;
   }
@@ -235,14 +235,16 @@ class VolumeLoaderContext {
 class WorkerLoader extends ThreadableVolumeLoader {
   private loaderId: number | undefined;
   private workerHandle: SharedLoadWorkerHandle;
+  private context: VolumeLoaderContext;
   private currentLoadId = -1;
   private currentLoadCallback: RawChannelDataCallback | undefined = undefined;
   private currentMetadataUpdateCallback: ((imageInfo?: ImageInfo, loadSpec?: LoadSpec) => void) | undefined = undefined;
 
-  constructor(loaderId: number, workerHandle: SharedLoadWorkerHandle) {
+  constructor(loaderId: number, workerHandle: SharedLoadWorkerHandle, context: VolumeLoaderContext) {
     super();
     this.loaderId = loaderId;
     this.workerHandle = workerHandle;
+    this.context = context;
   }
 
   private getLoaderId(): number {
@@ -250,6 +252,10 @@ class WorkerLoader extends ThreadableVolumeLoader {
       throw new Error("Tried to use a closed loader");
     }
     return this.loaderId;
+  }
+
+  getContext(): VolumeLoaderContext {
+    return this.context;
   }
 
   /** Close and permanently invalidate this loader. */


### PR DESCRIPTION
Review time: xsmall (~5min)

# Problem

`View3d` currently has a stray public property `loaderContext`, to give `View3d` a reference to a `VolumeLoaderContext` object which manages a worker thread and creates volume loaders on it. This seems to stem from an era when we thought `VolumeLoaderContext` might eventually become subsumed into `View3d`. But as we've used the loader API more for multi-scene collections, things haven't really shaken out that way. Instead, given the current flow (create a loader, create an image from the loader, put the image in the viewer), it seems to make more sense that the context be owned by the client which wants to create loaders.

That property currently is only used to bind a control in the secret Tweakpane menu. If we can create another way to get at the currently in-use `VolumeLoaderContext`, we can sand off an odd edge of the `View3d` API.

# Solution

Allow `VolumeLoaders` to store references to their context and to give those references via a thread.

This branch also picked up some unrelated polish changes in `TiffLoader`, which I made to make more values well-typed and which should be relatively uncontroversial.
