### PR TITLE
fix: Fixed bug where volume rendering would crash when the canvas is resized

### DIFF
--- a/src/PickVolume.ts
+++ b/src/PickVolume.ts
@@ -254,6 +254,10 @@ export default class PickVolume implements VolumeRenderImpl {
     this.setUniform("textureRes", this.settings.resolution);
 
     const depthTex = depthTexture ?? this.emptyPositionTex;
+    if (depthTex.image.width !== this.pickBuffer.width || depthTex.image.height !== this.pickBuffer.height) {
+      // Skip rendering when the texture resolution is mismatched
+      return;
+    }
     this.setUniform("textureDepth", depthTex);
     this.setUniform("usingPositionTexture", (depthTex as DepthTexture).isDepthTexture ? 0 : 1);
     this.setUniform("CLIP_NEAR", camera.near);

--- a/src/PickVolume.ts
+++ b/src/PickVolume.ts
@@ -254,10 +254,6 @@ export default class PickVolume implements VolumeRenderImpl {
     this.setUniform("textureRes", this.settings.resolution);
 
     const depthTex = depthTexture ?? this.emptyPositionTex;
-    if (depthTex.image.width !== this.pickBuffer.width || depthTex.image.height !== this.pickBuffer.height) {
-      // Skip rendering when the texture resolution is mismatched
-      return;
-    }
     this.setUniform("textureDepth", depthTex);
     this.setUniform("usingPositionTexture", (depthTex as DepthTexture).isDepthTexture ? 0 : 1);
     this.setUniform("CLIP_NEAR", camera.near);

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -184,8 +184,6 @@ export class ThreeJsPanel {
     if (parentElement) {
       this.renderer.setSize(parentElement.offsetWidth, parentElement.offsetHeight);
       this.meshRenderTarget.setSize(parentElement.offsetWidth, parentElement.offsetHeight);
-      this.meshRenderTarget.depthTexture.dispose();
-      this.meshRenderTarget.depthTexture = new DepthTexture(parentElement.offsetWidth, parentElement.offsetHeight);
     }
 
     this.timer = new Timing();

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -184,6 +184,8 @@ export class ThreeJsPanel {
     if (parentElement) {
       this.renderer.setSize(parentElement.offsetWidth, parentElement.offsetHeight);
       this.meshRenderTarget.setSize(parentElement.offsetWidth, parentElement.offsetHeight);
+      this.meshRenderTarget.depthTexture.dispose();
+      this.meshRenderTarget.depthTexture = new DepthTexture(parentElement.offsetWidth, parentElement.offsetHeight);
     }
 
     this.timer = new Timing();
@@ -633,6 +635,11 @@ export class ThreeJsPanel {
 
     this.renderer.setSize(w, h);
     this.meshRenderTarget.setSize(w, h);
+    // Force resize of depth texture now, otherwise it will not be resized until
+    // the next render and will cause texture size mismatches with the pick
+    // buffer.
+    this.meshRenderTarget.depthTexture?.dispose();
+    this.meshRenderTarget.depthTexture = new DepthTexture(w, h);
 
     this.perspectiveControls.handleResize();
     this.orthoControlsZ.handleResize();

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -200,6 +200,7 @@ export class View3d {
     if (this.image) {
       this.canvas3d.removeControlHandlers();
       this.canvas3d.animateFuncs = [];
+      this.canvas3d.postAnimateFuncs = [];
       this.scene.remove(this.image.sceneRoot);
     }
     return this.image;
@@ -416,7 +417,11 @@ export class View3d {
 
     this.canvas3d.animateFuncs.push(this.preRender.bind(this));
     this.canvas3d.animateFuncs.push(img.onAnimate.bind(img));
-    this.canvas3d.animateFuncs.push(img.fillPickBuffer.bind(img));
+    // NOTE: `fillPickBuffer` MUST run after render occurs. This is because the
+    // pick buffer needs to access the `meshRenderTarget`'s depth texture, but
+    // during a resize, the texture is disposed of and not recreated until the
+    // next render.
+    this.canvas3d.postAnimateFuncs.push(img.fillPickBuffer.bind(img));
 
     this.updatePerspectiveScaleBar(img.volume);
     this.updateTimestepIndicator(img.volume);


### PR DESCRIPTION
# Problem

Fixes a bug described in https://github.com/allen-cell-animated/timelapse-colorizer/issues/641 where the screen goes black during resize when the pick buffer is enabled.

The underlying cause was that, after a resize call to View3d, the depth texture for the `meshRenderTarget` gets disposed of and is not recreated until the next render. That meant that the disposed/deallocated texture was passed to `fillPickBuffer()` early, which caused a crash.

This change moves `fillPickBuffer` to run after the main render occurs, and adds a comment about why it needs to do so.


*Estimated review size: tiny, 2 minutes*

## Screenshots (optional):

Before:
![image](https://github.com/user-attachments/assets/4663e1af-ecf5-47f9-9791-3e4e6f81f0bb)

After:

![image](https://github.com/user-attachments/assets/40e79f98-4474-47a2-bb2e-333576c6626f)
