### PR TITLE
Import fixes for `Line3d`

### DIFF
--- a/src/Line3d.ts
+++ b/src/Line3d.ts
@@ -1,9 +1,10 @@
 import { Color, Euler, Group, Vector3 } from "three";
-import { IDrawableObject } from "./types";
-import { LineMaterial } from "three/addons/lines/LineMaterial";
-import { MESH_LAYER, OVERLAY_LAYER } from "./ThreeJsPanel";
-import { LineSegments2 } from "three/addons/lines/LineSegments2";
-import { LineSegmentsGeometry } from "three/addons/lines/LineSegmentsGeometry";
+
+import { IDrawableObject } from "./types.js";
+import { LineMaterial } from "three/addons/lines/LineMaterial.js";
+import { MESH_LAYER, OVERLAY_LAYER } from "./ThreeJsPanel.js";
+import { LineSegments2 } from "three/addons/lines/LineSegments2.js";
+import { LineSegmentsGeometry } from "three/addons/lines/LineSegmentsGeometry.js";
 
 const DEFAULT_VERTEX_BUFFER_SIZE = 1020;
 

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -1,4 +1,4 @@
-import { PrefetchDirection, TCZYX } from "./types";
+import { PrefetchDirection, TCZYX } from "./types.js";
 
 type TZYX = [number, number, number, number];
 


### PR DESCRIPTION
Review time: xsmall

Some imports in Line3d.ts are missing ".js" file extensions to be proper "fully specified" imports, which causes problems when linked into vole-app. I put the extensions in and things started working again.
