### PR TITLE
allow arbitrary dtypes for RawArrayLoader

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,8 @@
       <option value="cfeJson">CFE Json</option>
       <option value="abm">OME TIFF (ABM data)</option>
       <option value="procedural">Procedural</option>
+      <option value="procedural2">Procedural 2</option>
+      <option value="procedural3">Procedural 3</option>
     </select>
     <p style="margin: 2px">
       <button id="X">X</button>

--- a/public/index.ts
+++ b/public/index.ts
@@ -24,7 +24,7 @@ import {
 import { OpenCellLoader } from "../src/loaders/OpenCellLoader";
 import { State, TestDataSpec } from "./types";
 import VolumeLoaderContext from "../src/workers/VolumeLoaderContext";
-import { DATARANGE_UINT8, ColorizeFeature, type NumberType, type TypedArray, ARRAY_CONSTRUCTORS } from "../src/types";
+import { DATARANGE_UINT8, ColorizeFeature, type NumberType } from "../src/types";
 import { RawArrayLoaderOptions } from "../src/loaders/RawArrayLoader";
 
 const CACHE_MAX_SIZE = 1_000_000_000;
@@ -1059,25 +1059,6 @@ function goToZSlice(slice: number): boolean {
   // update UI if successful
 }
 
-// take a list of TypedArrays and concatenate them into a single TypedArray of the same Type:
-function concatenateArrays(arrays: TypedArray<NumberType>[], dtype: NumberType): TypedArray<NumberType> {
-  if (arrays.length === 0) {
-    throw new Error("Cannot concatenate empty array list");
-  }
-
-  const totalLength = arrays.reduce((acc, arr) => acc + arr.length, 0);
-
-  // Create a new array of the same type as the input arrays
-  const result = new ARRAY_CONSTRUCTORS[dtype](totalLength);
-
-  let offset = 0;
-  for (const arr of arrays) {
-    result.set(arr, offset);
-    offset += arr.length;
-  }
-  return result;
-}
-
 function createTestVolume(dtype: NumberType): RawArrayLoaderOptions {
   const sizeX = 64;
   const sizeY = 64;
@@ -1099,7 +1080,7 @@ function createTestVolume(dtype: NumberType): RawArrayLoaderOptions {
     VolumeMaker.createTorus(sizeX, sizeY, sizeZ, 24, 8),
     VolumeMaker.createCone(sizeX, sizeY, sizeZ, 24, 24),
   ];
-  const alldata = concatenateArrays(channelVolumes, dtype);
+  const alldata = VolumeMaker.concatenateArrays(channelVolumes, dtype);
   return {
     metadata: imgData,
     data: {

--- a/public/index.ts
+++ b/public/index.ts
@@ -24,7 +24,7 @@ import {
 import { OpenCellLoader } from "../src/loaders/OpenCellLoader";
 import { State, TestDataSpec } from "./types";
 import VolumeLoaderContext from "../src/workers/VolumeLoaderContext";
-import { DATARANGE_UINT8, ColorizeFeature } from "../src/types";
+import { DATARANGE_UINT8, ColorizeFeature, type NumberType, type TypedArray, ARRAY_CONSTRUCTORS } from "../src/types";
 import { RawArrayLoaderOptions } from "../src/loaders/RawArrayLoader";
 
 const CACHE_MAX_SIZE = 1_000_000_000;
@@ -115,7 +115,9 @@ const TEST_DATA: Record<string, TestDataSpec> = {
     type: VolumeFileFormat.TIFF,
     url: "https://animatedcell-test-data.s3.us-west-2.amazonaws.com/HAMILTONIAN_TERM_FOV_VSAHJUP_0000_000192.ome.tif",
   },
-  procedural: { type: VolumeFileFormat.DATA, url: "" },
+  procedural: { type: VolumeFileFormat.DATA, url: "", dtype: "uint8" },
+  procedural2: { type: VolumeFileFormat.DATA, url: "", dtype: "uint16" },
+  procedural3: { type: VolumeFileFormat.DATA, url: "", dtype: "float32" },
 };
 
 let view3D: View3d;
@@ -1057,9 +1059,17 @@ function goToZSlice(slice: number): boolean {
   // update UI if successful
 }
 
-function concatenateArrays(arrays: Uint8Array[]): Uint8Array {
+// take a list of TypedArrays and concatenate them into a single TypedArray of the same Type:
+function concatenateArrays(arrays: TypedArray<NumberType>[], dtype: NumberType): TypedArray<NumberType> {
+  if (arrays.length === 0) {
+    throw new Error("Cannot concatenate empty array list");
+  }
+
   const totalLength = arrays.reduce((acc, arr) => acc + arr.length, 0);
-  const result = new Uint8Array(totalLength);
+
+  // Create a new array of the same type as the input arrays
+  const result = new ARRAY_CONSTRUCTORS[dtype](totalLength);
+
   let offset = 0;
   for (const arr of arrays) {
     result.set(arr, offset);
@@ -1068,7 +1078,7 @@ function concatenateArrays(arrays: Uint8Array[]): Uint8Array {
   return result;
 }
 
-function createTestVolume(): RawArrayLoaderOptions {
+function createTestVolume(dtype: NumberType): RawArrayLoaderOptions {
   const sizeX = 64;
   const sizeY = 64;
   const sizeZ = 64;
@@ -1078,6 +1088,7 @@ function createTestVolume(): RawArrayLoaderOptions {
     sizeY,
     sizeZ,
     sizeC: 3,
+    dtype: dtype,
     physicalPixelSize: [1, 1, 1],
     spatialUnit: "",
     channelNames: ["DRAQ5", "EGFP", "SEG_Memb"],
@@ -1089,12 +1100,11 @@ function createTestVolume(): RawArrayLoaderOptions {
     VolumeMaker.createTorus(sizeX, sizeY, sizeZ, 24, 8),
     VolumeMaker.createCone(sizeX, sizeY, sizeZ, 24, 24),
   ];
-  const alldata = concatenateArrays(channelVolumes);
+  const alldata = concatenateArrays(channelVolumes, dtype);
   return {
     metadata: imgData,
     data: {
-      // expected to be "uint8" always
-      dtype: "uint8",
+      dtype: dtype,
       // [c,z,y,x]
       shape: [channelVolumes.length, sizeZ, sizeY, sizeX],
       // the bits (assumed uint8!!)
@@ -1130,7 +1140,7 @@ async function createLoader(data: TestDataSpec): Promise<IVolumeLoader[]> {
       const timesArray = [...Array(times + 1).keys()];
       path = timesArray.map((t) => src.replace("%%", t.toString()));
     } else if (data.type === VolumeFileFormat.DATA) {
-      const volumeInfo = createTestVolume();
+      const volumeInfo = createTestVolume(data.dtype || "uint8");
       options.fileType = VolumeFileFormat.DATA;
       options.rawArrayOptions = { data: volumeInfo.data, metadata: volumeInfo.metadata };
     }

--- a/public/index.ts
+++ b/public/index.ts
@@ -1088,7 +1088,6 @@ function createTestVolume(dtype: NumberType): RawArrayLoaderOptions {
     sizeY,
     sizeZ,
     sizeC: 3,
-    dtype: dtype,
     physicalPixelSize: [1, 1, 1],
     spatialUnit: "",
     channelNames: ["DRAQ5", "EGFP", "SEG_Memb"],

--- a/public/types.ts
+++ b/public/types.ts
@@ -1,9 +1,10 @@
 import { Volume, Light } from "../src";
 import { VolumeFileFormat } from "../src/loaders";
 import { IVolumeLoader } from "../src/loaders/IVolumeLoader";
+import { type NumberType } from "../src/types";
 
 export interface TestDataSpec {
-  type: VolumeFileFormat | "opencell" | "procedural";
+  type: VolumeFileFormat | "opencell";
   // TODO: replace array here with multi-scene handling at the loader level
   // one string is single scene
   // an array of strings is multiple scenes
@@ -11,6 +12,8 @@ export interface TestDataSpec {
   url: string | string[] | string[][];
   /** Optional fallback for JSON volumes which don't specify a value for `times` */
   times?: number;
+  /** data type for procedural only */
+  dtype?: NumberType;
 }
 
 export interface State {

--- a/src/VolumeMaker.ts
+++ b/src/VolumeMaker.ts
@@ -1,3 +1,5 @@
+import { type NumberType, type TypedArray, ARRAY_CONSTRUCTORS } from "./types.js";
+
 /**
  * Basic utility functions to create sample volume data
  * @class
@@ -9,14 +11,17 @@ export default class VolumeMaker {
    * @param {number} vy
    * @param {number} vz
    * @param {function} sdFunc A function f(x,y,z) that returns a distance. f < 0 will be the interior of the volume, and f>=0 will be outside.
+   * @param {TypedArrayConstructor} arrayConstructor The TypedArray constructor to use
    */
   static createVolume(
     vx: number,
     vy: number,
     vz: number,
-    sdFunc: (px: number, py: number, pz: number) => number
-  ): Uint8Array {
-    const data = new Uint8Array(vx * vy * vz).fill(0);
+    sdFunc: (px: number, py: number, pz: number) => number,
+    dtype: NumberType = "uint8"
+  ): TypedArray<NumberType> {
+    const ctor = ARRAY_CONSTRUCTORS[dtype];
+    const data = new ctor(vx * vy * vz).fill(0);
     const cx = vx / 2;
     const cy = vy / 2;
     const cz = vz / 2;
@@ -45,11 +50,24 @@ export default class VolumeMaker {
    * @param {number} vy
    * @param {number} vz
    * @param {number} radius
+   * @param {NumberType} dtype The data type for the output array
    */
-  static createSphere(vx: number, vy: number, vz: number, radius: number): Uint8Array {
-    return VolumeMaker.createVolume(vx, vy, vz, (px, py, pz) => {
-      return Math.sqrt(px * px + py * py + pz * pz) - radius;
-    });
+  static createSphere(
+    vx: number,
+    vy: number,
+    vz: number,
+    radius: number,
+    dtype: NumberType = "uint8"
+  ): TypedArray<NumberType> {
+    return VolumeMaker.createVolume(
+      vx,
+      vy,
+      vz,
+      (px, py, pz) => {
+        return Math.sqrt(px * px + py * py + pz * pz) - radius;
+      },
+      dtype
+    );
   }
 
   /**
@@ -59,16 +77,30 @@ export default class VolumeMaker {
    * @param {number} vz
    * @param {number} hx width of cap (?)
    * @param {number} hy depth of cap (?)
+   * @param {NumberType} dtype The data type for the output array
    */
-  static createCylinder(vx: number, vy: number, vz: number, hx: number, hy: number): Uint8Array {
+  static createCylinder(
+    vx: number,
+    vy: number,
+    vz: number,
+    hx: number,
+    hy: number,
+    dtype: NumberType = "uint8"
+  ): TypedArray<NumberType> {
     let dx, dy, mdx, mdy;
-    return VolumeMaker.createVolume(vx, vy, vz, (px, py, pz) => {
-      dx = Math.abs(Math.sqrt(px * px + pz * pz)) - hx;
-      dy = Math.abs(py) - hy;
-      mdx = Math.max(dx, 0.0);
-      mdy = Math.max(dy, 0.0);
-      return Math.min(Math.max(dx, dy), 0.0) + Math.sqrt(mdx * mdx + mdy * mdy);
-    });
+    return VolumeMaker.createVolume(
+      vx,
+      vy,
+      vz,
+      (px, py, pz) => {
+        dx = Math.abs(Math.sqrt(px * px + pz * pz)) - hx;
+        dy = Math.abs(py) - hy;
+        mdx = Math.max(dx, 0.0);
+        mdy = Math.max(dy, 0.0);
+        return Math.min(Math.max(dx, dy), 0.0) + Math.sqrt(mdx * mdx + mdy * mdy);
+      },
+      dtype
+    );
   }
 
   /**
@@ -78,14 +110,28 @@ export default class VolumeMaker {
    * @param {number} vz
    * @param {number} tx inner radius
    * @param {number} ty outer radius
+   * @param {NumberType} dtype The data type for the output array
    */
-  static createTorus(vx: number, vy: number, vz: number, tx: number, ty: number): Uint8Array {
+  static createTorus(
+    vx: number,
+    vy: number,
+    vz: number,
+    tx: number,
+    ty: number,
+    dtype: NumberType = "uint8"
+  ): TypedArray<NumberType> {
     let qx, qy;
-    return VolumeMaker.createVolume(vx, vy, vz, (px, py, pz) => {
-      qx = Math.sqrt(px * px + pz * pz) - tx;
-      qy = py;
-      return Math.sqrt(qx * qx + qy * qy) - ty;
-    });
+    return VolumeMaker.createVolume(
+      vx,
+      vy,
+      vz,
+      (px, py, pz) => {
+        qx = Math.sqrt(px * px + pz * pz) - tx;
+        qy = py;
+        return Math.sqrt(qx * qx + qy * qy) - ty;
+      },
+      dtype
+    );
   }
 
   /**
@@ -95,12 +141,26 @@ export default class VolumeMaker {
    * @param {number} vz
    * @param {number} cx base radius
    * @param {number} cy height
+   * @param {NumberType} dtype The data type for the output array
    */
-  static createCone(vx: number, vy: number, vz: number, cx: number, cy: number): Uint8Array {
+  static createCone(
+    vx: number,
+    vy: number,
+    vz: number,
+    cx: number,
+    cy: number,
+    dtype: NumberType = "uint8"
+  ): TypedArray<NumberType> {
     let q;
-    return VolumeMaker.createVolume(vx, vy, vz, (px, py, pz) => {
-      q = Math.sqrt(px * px + py * py);
-      return cx * q + cy * pz;
-    });
+    return VolumeMaker.createVolume(
+      vx,
+      vy,
+      vz,
+      (px, py, pz) => {
+        q = Math.sqrt(px * px + py * py);
+        return cx * q + cy * pz;
+      },
+      dtype
+    );
   }
 }

--- a/src/VolumeMaker.ts
+++ b/src/VolumeMaker.ts
@@ -163,4 +163,23 @@ export default class VolumeMaker {
       dtype
     );
   }
+
+  // take a list of TypedArrays and concatenate them into a single TypedArray of the same Type:
+  static concatenateArrays(arrays: TypedArray<NumberType>[], dtype: NumberType): TypedArray<NumberType> {
+    if (arrays.length === 0) {
+      throw new Error("Cannot concatenate empty array list");
+    }
+
+    const totalLength = arrays.reduce((acc, arr) => acc + arr.length, 0);
+
+    // Create a new array of the same type as the input arrays
+    const result = new ARRAY_CONSTRUCTORS[dtype](totalLength);
+
+    let offset = 0;
+    for (const arr of arrays) {
+      result.set(arr, offset);
+      offset += arr.length;
+    }
+    return result;
+  }
 }

--- a/src/VolumeMaker.ts
+++ b/src/VolumeMaker.ts
@@ -11,7 +11,7 @@ export default class VolumeMaker {
    * @param {number} vy
    * @param {number} vz
    * @param {function} sdFunc A function f(x,y,z) that returns a distance. f < 0 will be the interior of the volume, and f>=0 will be outside.
-   * @param {TypedArrayConstructor} arrayConstructor The TypedArray constructor to use
+   * @param {NumberType} dtype The data type for the output array
    */
   static createVolume(
     vx: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import RequestQueue from "./utils/RequestQueue.js";
 import SubscribableRequestQueue from "./utils/SubscribableRequestQueue.js";
 import Histogram from "./Histogram.js";
 import { Lut, remapControlPoints } from "./Lut.js";
-import { type ColorizeFeature, ViewportCorner } from "./types.js";
+import { type ColorizeFeature, type NumberType, ViewportCorner } from "./types.js";
 import { VolumeFileFormat, createVolumeLoader, PrefetchDirection } from "./loaders/index.js";
 import { LoadSpec } from "./loaders/IVolumeLoader.js";
 import { OMEZarrLoader } from "./loaders/OmeZarrLoader.js";
@@ -67,4 +67,5 @@ export {
   SKY_LIGHT,
   type CameraState,
   type ColorizeFeature,
+  type NumberType,
 };

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -152,7 +152,8 @@ class RawArrayLoader extends ThreadableVolumeLoader {
       if (requestedChannels && requestedChannels.length > 0 && !requestedChannels.includes(chindex)) {
         continue;
       }
-      const volSizePixels = this.data.shape[3] * this.data.shape[2] * this.data.shape[1]; // x*y*z pixels * 1 byte/pixel
+      // x*y*z pixels
+      const volSizePixels = this.data.shape[3] * this.data.shape[2] * this.data.shape[1];
       const ctor = ARRAY_CONSTRUCTORS[this.data.dtype];
       const channelData = new ctor(
         this.data.buffer.buffer,


### PR DESCRIPTION
# Problem

In support of nbvv, because channel data now supports any numeric dtype, nbvv no longer needs to convert data to uint8.  However, the RawArrayLoader needs to relax its requirement for uint8 data.

# Solution

Let RawArrayLoader have any dtype.
Update the test app to load procedurals with 3 different dtypes.

The RawArrayData type is no longer required to be uint8 only.  I believe this is not breaking but haven't yet tested against the vole-app.

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to Verify:

Can look at test app and load the 3 procedurals and verify that they look the same.

