### PR TITLE
Fix/isosurface scale

### DIFF
--- a/src/MeshVolume.ts
+++ b/src/MeshVolume.ts
@@ -46,6 +46,10 @@ export default class MeshVolume implements IDrawableObject {
     this.meshRoot = new Object3D(); //create an empty container
     this.meshRoot.name = "Mesh Surface Group";
 
+    // compensating for generated isosurface vertex coordinates
+    // arguably this could be set on meshPivot
+    this.meshRoot.scale.set(0.5, 0.5, 0.5);
+
     // handle transform ordering for giving the meshroot a rotation about a pivot point
     this.meshPivot = new Group();
     this.meshPivot.name = "MeshContainerNode";

--- a/src/MeshVolume.ts
+++ b/src/MeshVolume.ts
@@ -48,7 +48,7 @@ export default class MeshVolume implements IDrawableObject {
 
     // compensating for generated isosurface vertex coordinates
     // arguably this could be set on meshPivot
-    this.meshRoot.scale.set(0.5, 0.5, 0.5);
+    this.meshRoot.scale.setScalar(0.5);
 
     // handle transform ordering for giving the meshroot a rotation about a pivot point
     this.meshPivot = new Group();

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -1043,10 +1043,16 @@ export class View3d {
 
     const addFolderForLight = (light: ThreeLight, title: string): void => {
       const folder = lights.addFolder({ title, expanded: false });
-      folder.addInput(light, "color", { color: { type: "float" } });
-      folder.addInput(light, "intensity", { min: 0 });
+      folder.addInput(light, "color", { color: { type: "float" } }).on("change", (_event) => {
+        this.redraw();
+      });
+      folder.addInput(light, "intensity", { min: 0 }).on("change", (_event) => {
+        this.redraw();
+      });
       if (!(light as AmbientLight).isAmbientLight) {
-        folder.addInput(light, "position");
+        folder.addInput(light, "position").on("change", (_event) => {
+          this.redraw();
+        });
       }
     };
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -1043,16 +1043,10 @@ export class View3d {
 
     const addFolderForLight = (light: ThreeLight, title: string): void => {
       const folder = lights.addFolder({ title, expanded: false });
-      folder.addInput(light, "color", { color: { type: "float" } }).on("change", (_event) => {
-        this.redraw();
-      });
-      folder.addInput(light, "intensity", { min: 0 }).on("change", (_event) => {
-        this.redraw();
-      });
+      folder.addInput(light, "color", { color: { type: "float" } }).on("change", (_event) => this.redraw());
+      folder.addInput(light, "intensity", { min: 0 }).on("change", (_event) => this.redraw());
       if (!(light as AmbientLight).isAmbientLight) {
-        folder.addInput(light, "position").on("change", (_event) => {
-          this.redraw();
-        });
+        folder.addInput(light, "position").on("change", (_event) => this.redraw());
       }
     };
 

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -823,7 +823,7 @@ export default class VolumeDrawable {
 
     // remove old 3d object from scene
     if (this.renderMode === RenderMode.SLICE || this.renderMode === RenderMode.RAYMARCH) {
-      this.sceneRoot.remove(this.meshVolume.get3dObject());
+      this.childObjectsGroup.remove(this.meshVolume.get3dObject());
     }
     this.sceneRoot.remove(this.volumeRendering.get3dObject());
 
@@ -856,7 +856,7 @@ export default class VolumeDrawable {
       if (this.renderUpdateListener) {
         this.renderUpdateListener(0);
       }
-      this.sceneRoot.add(this.meshVolume.get3dObject());
+      this.childObjectsGroup.add(this.meshVolume.get3dObject());
     }
 
     // add new 3d object to scene

--- a/src/constants/lights.ts
+++ b/src/constants/lights.ts
@@ -4,7 +4,7 @@ const spotlightSettings = Object.freeze({
   angle: 36 * MathUtils.DEG2RAD,
   castShadow: false,
   color: 0xffffff,
-  intensity: 0.4,
+  intensity: 15.0,
   position: {
     x: -4,
     y: 3.5,
@@ -14,13 +14,13 @@ const spotlightSettings = Object.freeze({
 
 const ambientLightSettings = Object.freeze({
   color: 0xffffff,
-  intensity: 0.6,
+  intensity: 1.75,
 });
 
 const reflectedLightSettings = Object.freeze({
   castShadow: false,
   color: 0xff88aa,
-  intensity: 0.2,
+  intensity: 2.0,
   position: {
     x: 1,
     y: -5,
@@ -31,7 +31,7 @@ const reflectedLightSettings = Object.freeze({
 const fillLightSettings = Object.freeze({
   castShadow: false,
   color: 0xe8d1a9,
-  intensity: 0.15,
+  intensity: 1.5,
   position: {
     x: 2.5,
     y: 0.2,


### PR DESCRIPTION
Review time: tiny (5-10min)

Resolves allen-cell-animated/vole-app#397 by fixing multiple bugs related to isosurfaces:
- Isosurfaces were not getting scaled correctly to the volume. This was a regression introduced in #321, which slightly reorganized isosurface meshes under a new, more generic framework for managing the children of a `VolumeDrawable`.
- The lighting on surfaces was too dim by default. Seemingly at some point the scale for light intensity in three.js changed.
- Changing the lighting properties in the secret "advanced settings" menu (Ctrl+Alt+1) now triggers an immediate redraw with the new settings.
